### PR TITLE
Adapt transitfeed project for compatibility with Python 2 and 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ merge-results.html
 build
 dist
 MANIFEST
+.idea

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-> ⚠️ **NOTE:**  This project is no longer actively maintained.  For up-to-date GTFS validation tools, see the https://github.com/MobilityData/gtfs-validator project. ⚠️
+# Futurized Python-3-compatible Transitfeed fork
+
+This repo contains a fork of the Google [`transitfeed`](https://github.com/google/transitfeed) project. We have run the Python Future `futurize` command on the codebase to work towards Python 3 compatibility. We also made a couple of adjustments to address errors that were raised in use cases we encountered in our usage of the tool.
+
+# Original Project README
 
 ## transitfeed
 

--- a/examples/filter_unused_stops.py
+++ b/examples/filter_unused_stops.py
@@ -44,7 +44,7 @@ def main():
 
   print("Removing unused stops...")
   removed = 0
-  for stop_id, stop in schedule.stops.items():
+  for stop_id, stop in list(schedule.stops.items()):
     if not stop.GetTrips(schedule):
       removed += 1
       del schedule.stops[stop_id]

--- a/examples/google_random_queries.py
+++ b/examples/google_random_queries.py
@@ -24,7 +24,12 @@ look at the time of each leg. Also check the route names and headsigns are
 formatted correctly and not redundant.
 """
 from __future__ import print_function
+from __future__ import division
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from past.utils import old_div
 from datetime import datetime
 from datetime import timedelta
 import math
@@ -33,8 +38,8 @@ import os.path
 import random
 import sys
 import transitfeed
-import urllib
-import urlparse
+import urllib.request, urllib.parse, urllib.error
+import urllib.parse
 
 
 def Distance(lat0, lng0, lat1, lng1):
@@ -70,8 +75,8 @@ def AddNoiseToLatLng(lat, lng):
   """Add up to 500m of error to each coordinate of lat, lng."""
   m_per_tenth_lat = Distance(lat, lng, lat + 0.1, lng)
   m_per_tenth_lng = Distance(lat, lng, lat, lng + 0.1)
-  lat_per_100m = 1 / m_per_tenth_lat * 10
-  lng_per_100m = 1 / m_per_tenth_lng * 10
+  lat_per_100m = old_div(1, m_per_tenth_lat) * 10
+  lng_per_100m = old_div(1, m_per_tenth_lng) * 10
   return (lat + (lat_per_100m * 5 * (random.random() * 2 - 1)),
           lng + (lng_per_100m * 5 * (random.random() * 2 - 1)))
 
@@ -105,8 +110,8 @@ def LatLngsToGoogleUrl(source, destination, dt):
             "dirflg": "r",
             "ie": "UTF8",
             "oe": "UTF8"}
-  url = urlparse.urlunsplit(("http", "maps.google.com", "/maps",
-                             urllib.urlencode(params), ""))
+  url = urllib.parse.urlunsplit(("http", "maps.google.com", "/maps",
+                             urllib.parse.urlencode(params), ""))
   return url
 
 

--- a/examples/shuttle_from_xmlfeed.py
+++ b/examples/shuttle_from_xmlfeed.py
@@ -18,13 +18,17 @@
 database dumps its contents in XML. This scripts converts the proprietary XML
 format into a Google Transit Feed Specification file.
 """
+from __future__ import division
 
+from future import standard_library
+standard_library.install_aliases()
+from past.utils import old_div
 import datetime
 from optparse import OptionParser
 import os.path
 import re
 import transitfeed
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 try:
   import xml.etree.ElementTree as ET  # python 2.5
@@ -45,7 +49,7 @@ class NoUnusedStopExceptionProblemReporter(transitfeed.ProblemReporter):
     pass
 
 def SaveFeed(input, output):
-  tree = ET.parse(urllib.urlopen(input))
+  tree = ET.parse(urllib.request.urlopen(input))
 
   schedule = transitfeed.Schedule()
   service_period = schedule.GetDefaultServicePeriod()
@@ -83,7 +87,7 @@ def SaveFeed(input, output):
           trip_id=xml_route.attrib['id'])
       trip_stops = []  # Build a list of (time, Stop) tuples
       for xml_schedule in xml_route.getiterator('schedule'):
-        trip_stops.append( (int(xml_schedule.attrib['time']) / 1000,
+        trip_stops.append( (old_div(int(xml_schedule.attrib['time']), 1000),
                             stops[xml_schedule.attrib['stopId']]) )
       trip_stops.sort()  # Sort by time
       for (time, stop) in trip_stops:

--- a/examples/table.py
+++ b/examples/table.py
@@ -33,6 +33,7 @@
 # transit feed builder.
 
 from __future__ import print_function
+from builtins import range
 import transitfeed
 from optparse import OptionParser
 import re

--- a/extensions/googletransit/extension_util.py
+++ b/extensions/googletransit/extension_util.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from builtins import str
 from .pybcp47 import Bcp47LanguageParser
 from transitfeed import problems as problems_class
 from transitfeed import util

--- a/extensions/googletransit/pybcp47/bcp47languageparser.py
+++ b/extensions/googletransit/pybcp47/bcp47languageparser.py
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import division
+from builtins import next
+from builtins import map
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import codecs
 import os
 from pkg_resources import resource_string
@@ -136,13 +142,13 @@ class Bcp47LanguageParser(object):
                                     line_number)
 
   def IntStr26ToInt(self, int_str):
-    return reduce(lambda x, y: 26 * x + y, map(string.lowercase.index, int_str))
+    return reduce(lambda x, y: 26 * x + y, list(map(string.lowercase.index, int_str)))
 
   def IntToIntStr26(self, int_value, int_str=''):
     if int_value == 0:
       return int_str
     return self.IntToIntStr26(
-        int_value/26, string.lowercase[int_value%26] + int_str)
+        old_div(int_value,26), string.lowercase[int_value%26] + int_str)
 
   def _AddSubtagFromRegistryFile(self, current_type, current_tag,
                                  current_descriptions, current_prefixes,

--- a/extensions/googletransit/pybcp47/testpybcp47.py
+++ b/extensions/googletransit/pybcp47/testpybcp47.py
@@ -17,6 +17,7 @@
 # Unit tests for the bcp47languageparser module.
 
 from __future__ import absolute_import
+from builtins import str
 import codecs
 import os
 import unittest
@@ -31,19 +32,19 @@ class PyBcp47TestCase(unittest.TestCase):
     # valid. The registry file in this package is originally downloaded from
     # http://www.iana.org/assignments/language-subtag-registry. Formatting
     # rules of this file can be found at http://tools.ietf.org/html/rfc5646
-    for tag in self.bcp47parser.grandfathereds.keys():
+    for tag in list(self.bcp47parser.grandfathereds.keys()):
       self.assertTrue(self.bcp47parser.IsWellformed(tag),
                       "Grandfathered tag '%s' in language-subtag-registry.txt "
                       "seems to be invalid!" % (tag))
-    for tag in self.bcp47parser.redundants.keys():
+    for tag in list(self.bcp47parser.redundants.keys()):
       self.assertTrue(self.bcp47parser.IsWellformed(tag),
                       "Redundant tag '%s' in language-subtag-registry.txt "
                       "seems to be invalid!" % (tag))
-    for tag in self.bcp47parser.languages.keys():
+    for tag in list(self.bcp47parser.languages.keys()):
       self.assertTrue(self.bcp47parser.IsWellformedSubtag(tag, "lang"),
                       "Language subtag '%s' in language-subtag-registry.txt "
                       "seems to be invalid!" % (tag))
-    for tag in self.bcp47parser.extlangs.keys():
+    for tag in list(self.bcp47parser.extlangs.keys()):
       # extlangs contains each for each extlang just the tag and the tag
       # combined with its prefix. E.g. 'aao' and 'ar-aao'.
       extlang_parts = tag.split("-")
@@ -51,15 +52,15 @@ class PyBcp47TestCase(unittest.TestCase):
       self.assertTrue(self.bcp47parser.IsWellformedSubtag(extlang, "extlang"),
                       "Extlang subtag '%s' in language-subtag-registry.txt "
                       "seems to be invalid!" % (tag))
-    for tag in self.bcp47parser.scripts.keys():
+    for tag in list(self.bcp47parser.scripts.keys()):
       self.assertTrue(self.bcp47parser.IsWellformedSubtag(tag, "script"),
                       "Script subtag '%s' in language-subtag-registry.txt "
                       "seems to be invalid!" % (tag))
-    for tag in self.bcp47parser.regions.keys():
+    for tag in list(self.bcp47parser.regions.keys()):
       self.assertTrue(self.bcp47parser.IsWellformedSubtag(tag, "region"),
                       "Region subtag '%s' in language-subtag-registry.txt "
                       "seems to be invalid!" % (tag))
-    for tag in self.bcp47parser.variants.keys():
+    for tag in list(self.bcp47parser.variants.keys()):
       self.assertTrue(self.bcp47parser.IsWellformedSubtag(tag, "variant"),
                       "Variant subtag '%s' in language-subtag-registry.txt "
                       "seems to be invalid!" % (tag))

--- a/extensions/googletransit/route.py
+++ b/extensions/googletransit/route.py
@@ -29,7 +29,7 @@ class Route(transitfeed.Route):
 
   _FIELD_NAMES = transitfeed.Route._FIELD_NAMES + [ 'co2_per_km' ]
 
-  _ROUTE_TYPES = dict(transitfeed.Route._ROUTE_TYPES.items() + {
+  _ROUTE_TYPES = dict(list(transitfeed.Route._ROUTE_TYPES.items()) + list({
     8: {'name':'Horse Carriage', 'max_speed':50},
     9: {'name':'Intercity Bus', 'max_speed':120},
     10: {'name':'Commuter Train', 'max_speed':150},
@@ -72,7 +72,7 @@ class Route(transitfeed.Route):
     1700: {'name':'MiscellaneousService', 'max_speed':100},
     1701: {'name':'CableCar', 'max_speed':50},
     1702: {'name':'HorseDrawnCarriage', 'max_speed':50}
-    }.items())
+    }.items()))
 
   _ROUTE_TYPE_IDS = set(_ROUTE_TYPES.keys())
   # _ROUTE_TYPE_NAMES is not getting updated as we should not continue to allow

--- a/feedvalidator.py
+++ b/feedvalidator.py
@@ -20,7 +20,13 @@
 For usage information run feedvalidator.py --help
 """
 from __future__ import print_function
+from __future__ import division
 
+from builtins import zip
+from builtins import input
+from past.builtins import basestring
+from builtins import object
+from past.utils import old_div
 import bisect
 import codecs
 import datetime
@@ -97,7 +103,7 @@ def CalendarSummary(schedule):
   for date, day_trips, day_departures in date_trips_departures:
     trips += day_trips
     trips_dates[day_trips].append(date)
-  mean_trips = trips / len(date_trips_departures)
+  mean_trips = old_div(trips, len(date_trips_departures))
   max_trips = max(trips_dates.keys())
   min_trips = min(trips_dates.keys())
 
@@ -234,12 +240,12 @@ class LimitPerTypeProblemAccumulator(transitfeed.ProblemAccumulatorInterface):
     self._type_to_name_to_problist[e.GetType()][e.__class__.__name__].Add(e)
 
   def ErrorCount(self):
-    error_sets = self._type_to_name_to_problist[TYPE_ERROR].values()
-    return sum(map(lambda v: v.count, error_sets))
+    error_sets = list(self._type_to_name_to_problist[TYPE_ERROR].values())
+    return sum([v.count for v in error_sets])
 
   def WarningCount(self):
-    warning_sets = self._type_to_name_to_problist[TYPE_WARNING].values()
-    return sum(map(lambda v: v.count, warning_sets))
+    warning_sets = list(self._type_to_name_to_problist[TYPE_WARNING].values())
+    return sum([v.count for v in warning_sets])
 
   def ProblemList(self, problem_type, class_name):
     """Return the BoundedProblemList object for given type and class."""
@@ -299,9 +305,9 @@ class HTMLCountingProblemAccumulator(LimitPerTypeProblemAccumulator):
     """Append HTML version of e to list output."""
     d = e.GetDictToFormat()
     for k in ('file_name', 'feedname', 'column_name'):
-      if k in d.keys():
+      if k in list(d.keys()):
         d[k] = '<code>%s</code>' % d[k]
-    if 'url' in d.keys():
+    if 'url' in list(d.keys()):
       d['url'] = '<a href="%(url)s">%(url)s</a>' % d
 
     problem_text = e.FormatProblem(d).replace('\n', '<br>')
@@ -379,7 +385,7 @@ class HTMLCountingProblemAccumulator(LimitPerTypeProblemAccumulator):
 
     if self.HasNotices():
       summary = ('<h3 class="issueHeader">Notices:</h3>' + 
-          self.FormatType("Notice", self.ProblemListMap(TYPE_NOTICE).items()) +
+          self.FormatType("Notice", list(self.ProblemListMap(TYPE_NOTICE).items())) +
           summary)
 
     basename = os.path.basename(feed_location)
@@ -493,10 +499,10 @@ FeedValidator</a> version %s on %s.
     f.write(transitfeed.EncodeUnicode(output_prefix))
     if self.ProblemListMap(TYPE_ERROR):
       f.write('<h3 class="issueHeader">Errors:</h3>')
-      f.write(self.FormatType("Error", self.ProblemListMap(TYPE_ERROR).items()))
+      f.write(self.FormatType("Error", list(self.ProblemListMap(TYPE_ERROR).items())))
     if self.ProblemListMap(TYPE_WARNING):
       f.write('<h3 class="issueHeader">Warnings:</h3>')
-      f.write(self.FormatType("Warning", self.ProblemListMap(TYPE_WARNING).items()))
+      f.write(self.FormatType("Warning", list(self.ProblemListMap(TYPE_WARNING).items())))
     f.write(transitfeed.EncodeUnicode(output_suffix))
 
 
@@ -681,7 +687,7 @@ https://github.com/google/transitfeed/wiki/FeedValidator
 
   if not len(args) == 1:
     if options.manual_entry:
-      feed = raw_input('Enter Feed Location: ')
+      feed = input('Enter Feed Location: ')
     else:
       parser.error('You must provide the path of a single feed')
   else:

--- a/gtfsscheduleviewer/marey_graph.py
+++ b/gtfsscheduleviewer/marey_graph.py
@@ -33,12 +33,19 @@ http://transliteracies.english.ucsb.edu/post/research-project/research-clearingh
 
 """
 from __future__ import print_function
+from __future__ import division
 
+from builtins import zip
+from builtins import hex
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import itertools
 import transitfeed
 
 
-class MareyGraph:
+class MareyGraph(object):
   """Produces and caches marey graph from transit feed data."""
 
   _MAX_ZOOM = 5.0 # change docstring of ChangeScaleFactor if this changes
@@ -229,7 +236,7 @@ class MareyGraph:
       [0,33,140, ... ,X]
     """
     e_dists2 = [transitfeed.ApproximateDistanceBetweenStops(stop, tail) for
-                (stop,tail) in itertools.izip(slist, slist[1:])]
+                (stop,tail) in zip(slist, slist[1:])]
 
     return e_dists2
 
@@ -289,7 +296,7 @@ class MareyGraph:
       trip = triplist[0]
 
     t_dists2 = [DistanceInTravelTime(stop[3],tail[2]) for (stop,tail)
-                 in itertools.izip(trip.GetTimeStops(),trip.GetTimeStops()[1:])]
+                 in zip(trip.GetTimeStops(),trip.GetTimeStops()[1:])]
     return t_dists2
 
   def _AddWarning(self, str):
@@ -324,7 +331,7 @@ class MareyGraph:
       if not colpar:
         if t.service_id not in servlist:
           servlist.append(t.service_id)
-        shade = int(servlist.index(t.service_id) * (200/len(servlist))+55)
+        shade = int(servlist.index(t.service_id) * (old_div(200,len(servlist)))+55)
         color = "#00%s00" %  hex(shade)[2:4]
       else:
         color=colpar
@@ -391,7 +398,7 @@ class MareyGraph:
                        % (i + .5 + 20, 20, i + .5 + 20, self._gheight))
         tmpstrs.append('<text class="Label" x="%d" y="%d">%d</text>'
                        % (i + 20, 20,
-                         (i / self._hour_grid + self._offset) % 24))
+                         (old_div(i, self._hour_grid) + self._offset) % 24))
       else:
         tmpstrs.append('<polyline class="SubHour" points="%d,%d,%d,%d" />' \
                        % (i + .5 + 20, 20, i + .5 + 20, self._gheight))
@@ -463,8 +470,8 @@ class MareyGraph:
     self._decorators.append(tmpstr)
 
   def SetSpan(self, first_arr, last_arr, mint=5 ,maxt=30):
-    s_hour = (first_arr / 3600) - 1
-    e_hour = (last_arr / 3600) + 1
+    s_hour = (old_div(first_arr, 3600)) - 1
+    e_hour = (old_div(last_arr, 3600)) + 1
     self._offset = max(min(s_hour, 23), 0)
     self._tspan = max(min(e_hour - s_hour, maxt), mint)
     self._gwidth = self._tspan * self._hour_grid

--- a/kmlparser.py
+++ b/kmlparser.py
@@ -29,6 +29,7 @@ For line geometries, information about shapes is extracted from a kml file.
 """
 from __future__ import print_function
 
+from builtins import object
 import re
 import string
 import sys

--- a/kmlwriter.py
+++ b/kmlwriter.py
@@ -70,6 +70,9 @@ in a folder hierarchy which looks like this at the top level:
 """
 from __future__ import print_function
 
+from past.builtins import cmp
+from builtins import str
+from builtins import object
 try:
   import xml.etree.ElementTree as ET  # python 2.5
 except ImportError as e:
@@ -401,7 +404,7 @@ class KMLWriter(object):
     """
 
     def CreateElements(current_element, current_dict):
-      for (key, value) in current_dict.iteritems():
+      for (key, value) in list(current_dict.items()):
         element = ET.SubElement(current_element, key)
         if isinstance(value,dict):
           CreateElements(element, value)
@@ -458,7 +461,7 @@ class KMLWriter(object):
       return None
 
     # sort by number of trips using the pattern
-    pattern_trips = pattern_id_to_trips.values()
+    pattern_trips = list(pattern_id_to_trips.values())
     pattern_trips.sort(lambda a, b: cmp(len(b), len(a)))
 
     folder = self._CreateFolder(parent, 'Patterns', visible)
@@ -500,7 +503,7 @@ class KMLWriter(object):
       return None
 
     # sort by the number of trips using the shape
-    shape_id_to_trips_items = shape_id_to_trips.items()
+    shape_id_to_trips_items = list(shape_id_to_trips.items())
     shape_id_to_trips_items.sort(lambda a, b: cmp(len(b[1]), len(a[1])))
 
     folder = self._CreateFolder(parent, 'Shapes', visible)

--- a/merge.py
+++ b/merge.py
@@ -39,6 +39,7 @@ Run merge.py --help for a list of the possible options.
 from __future__ import print_function
 
 
+from builtins import object
 __author__ = 'timothy.stranex@gmail.com (Timothy Stranex)'
 
 
@@ -237,7 +238,7 @@ class HTMLProblemAccumulator(transitfeed.ProblemAccumulatorInterface):
 
     prefix = '<h2 class="issueHeader">%s:</h2>' % heading
     dataset_sections = []
-    for dataset_merger, problems in dataset_problems.items():
+    for dataset_merger, problems in list(dataset_problems.items()):
       dataset_sections.append('<h3>%s</h3><ol>%s</ol>' % (
           dataset_merger.FILE_NAME, '\n'.join(problems)))
     body = '\n'.join(dataset_sections)
@@ -271,7 +272,7 @@ class HTMLProblemAccumulator(transitfeed.ProblemAccumulatorInterface):
     items = []
     for e in self._notices:
       d = e.GetDictToFormat()
-      if 'url' in d.keys():
+      if 'url' in list(d.keys()):
         d['url'] = '<a href="%(url)s">%(url)s</a>' % d
       items.append('<li class="notice">%s</li>' %
                    e.FormatProblem(d).replace('\n', '<br>'))
@@ -505,7 +506,7 @@ class DataSetMerger(object):
       MergeError: One of the attributes was not able to be merged.
     """
     migrated = self._Migrate(b, self.feed_merger.b_schedule, False)
-    for attr, merger in scheme.items():
+    for attr, merger in list(scheme.items()):
       a_attr = getattr(a, attr, None)
       b_attr = getattr(b, attr, None)
       try:
@@ -605,11 +606,11 @@ class DataSetMerger(object):
       migrated = self._Migrate(orig, self.feed_merger.b_schedule)
       b_orig_migrated[self._GetId(migrated)] = (orig, migrated)
 
-    for migrated_id, (orig, migrated) in b_orig_migrated.items():
+    for migrated_id, (orig, migrated) in list(b_orig_migrated.items()):
       self._Add(None, orig, migrated)
       self._num_not_merged_b += 1
 
-    for migrated_id, (orig, migrated) in a_orig_migrated.items():
+    for migrated_id, (orig, migrated) in list(a_orig_migrated.items()):
       if migrated_id not in b_orig_migrated:
         self._Add(orig, None, migrated)
         self._num_not_merged_a += 1
@@ -1634,7 +1635,7 @@ class FeedMerger(object):
                     'shape_id': schedule.GetShapeList()}
 
     max_postfix_number = 0
-    for id_name, entity_list in id_data_sets.items():
+    for id_name, entity_list in list(id_data_sets.items()):
       for entity in entity_list:
         entity_id = getattr(entity, id_name)
         postfix_number = ExtractPostfixNumber(entity_id)

--- a/misc/find_pytz_transition_times.py
+++ b/misc/find_pytz_transition_times.py
@@ -24,6 +24,7 @@ based on zic.c or zdump.c in tzcode2009k.tar.gz but this seemed much easier.
 """
 from __future__ import print_function
 
+from builtins import zip
 import pytz
 import datetime
 

--- a/misc/sql_loop.py
+++ b/misc/sql_loop.py
@@ -18,6 +18,8 @@
 from __future__ import print_function
 
 
+from builtins import next
+from builtins import str
 import cmd
 import re
 import csv
@@ -154,7 +156,7 @@ def main():
     cursor.execute(args[0])
     writer.writerow([desc[0] for desc in cursor.description])
     for row in cursor:
-      writer.writerow([unicode(v).encode('utf8') for v in row])
+      writer.writerow([str(v).encode('utf8') for v in row])
   elif options.interactive:
     loop = SqlLoop(cursor)
     loop.cmdloop()

--- a/misc/traceplus.py
+++ b/misc/traceplus.py
@@ -34,7 +34,7 @@ def MakeExpandedTrace(frame_records):
           dump.append(' --> %s' % line)
         else:
           dump.append('     %s' % line)
-    for local_name, local_val in frame_obj.f_locals.items():
+    for local_name, local_val in list(frame_obj.f_locals.items()):
       try:
         local_type_name = type(local_val).__name__
       except Exception as e:

--- a/misc/traceplus_example.py
+++ b/misc/traceplus_example.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 
 from __future__ import print_function
+from __future__ import division
+from past.utils import old_div
 import argparse
 parser = argparse.ArgumentParser()
 
@@ -8,7 +10,7 @@ def CrashOrNot(crash_commanded):
   some_value = 1
   if crash_commanded:
     some_value -= 1
-  print("All good, you get {}".format(1 / some_value))
+  print("All good, you get {}".format(old_div(1, some_value)))
 
 def main():
   parser = argparse.ArgumentParser()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 enum34
 pytz
+future

--- a/shape_importer.py
+++ b/shape_importer.py
@@ -20,6 +20,9 @@ Requires the ogr python package.
 """
 from __future__ import print_function
 
+from builtins import zip
+from builtins import str
+from builtins import range
 __author__ = 'chris.harrelson.code@gmail.com (Chris Harrelson)'
 
 import csv
@@ -215,7 +218,7 @@ def main(key_cols):
   for route in schedule.GetRouteList():
     print('Processing route', route.route_short_name)
     patterns = route.GetPatternIdTripDict()
-    for pattern_id, trips in patterns.iteritems():
+    for pattern_id, trips in list(patterns.items()):
       pattern_count += 1
       pattern = trips[0].GetPattern()
 

--- a/tests/test_visualize_pathways.py
+++ b/tests/test_visualize_pathways.py
@@ -1,3 +1,4 @@
+from builtins import str
 import os.path
 import unittest
 

--- a/tests/testexamples.py
+++ b/tests/testexamples.py
@@ -3,17 +3,19 @@
 # Test the examples to make sure they are not broken
 
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 import os
 import re
 import transitfeed
 import unittest
-import urllib
+import urllib.request, urllib.parse, urllib.error
 from tests import util
 
 class WikiExample(util.TempDirTestCaseBase):
   # Download example from wiki and run it
   def runTest(self):
-    wiki_source = urllib.urlopen(
+    wiki_source = urllib.request.urlopen(
       'https://raw.githubusercontent.com/wiki/google/transitfeed/TransitFeed.md'
     ).read()
     m = re.search(r'```\s*(import transitfeed.*)```', wiki_source, re.DOTALL)

--- a/tests/testfeedvalidator.py
+++ b/tests/testfeedvalidator.py
@@ -18,6 +18,10 @@
 # for a valid feed and a feed with errors.
 
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
+from builtins import object
 import datetime
 import feedvalidator
 import os.path
@@ -26,8 +30,8 @@ from tests import util
 import transitfeed
 from transitfeed.compat import StringIO
 import unittest
-from urllib2 import HTTPError, URLError
-import urllib2
+from urllib.error import HTTPError, URLError
+import urllib.request, urllib.error, urllib.parse
 import zipfile
 
 
@@ -272,7 +276,7 @@ class CalendarSummaryTestCase(util.TestCase):
       self.assertEquals({}, result)
 
 
-class MockOptions:
+class MockOptions(object):
   """Pretend to be an optparse options object suitable for testing."""
   def __init__(self):
     self.limit_per_type = 5

--- a/tests/testkmlwriter.py
+++ b/tests/testkmlwriter.py
@@ -17,6 +17,7 @@
 """Unit tests for the kmlwriter module."""
 
 from __future__ import absolute_import
+from builtins import map
 import os
 import tempfile
 import unittest

--- a/tests/testmerge.py
+++ b/tests/testmerge.py
@@ -18,6 +18,9 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from builtins import object
 __author__ = 'timothy.stranex@gmail.com (Timothy Stranex)'
 
 import merge
@@ -145,7 +148,7 @@ class TestApproximateDistanceBetweenPoints(util.TestCase):
 
 class TestSchemedMerge(util.TestCase):
 
-  class TestEntity:
+  class TestEntity(object):
     """A mock entity (like Route or Stop) for testing."""
 
     def __init__(self, x, y, z):
@@ -169,7 +172,7 @@ class TestSchemedMerge(util.TestCase):
     self.ds._Migrate = Migrate
 
   def testMergeIdentical(self):
-    class TestAttrib:
+    class TestAttrib(object):
       """An object that is equal to everything."""
 
       def __cmp__(self, b):
@@ -299,7 +302,7 @@ class TestSchemedMerge(util.TestCase):
 
 class TestFeedMerger(util.TestCase):
 
-  class Merger:
+  class Merger(object):
     def __init__(self, test, n, should_fail=False):
       self.test = test
       self.n = n
@@ -323,13 +326,13 @@ class TestFeedMerger(util.TestCase):
     for i in range(10):
       self.fm.AddMerger(TestFeedMerger.Merger(self, i))
     self.assert_(self.fm.MergeSchedules())
-    self.assertEquals(self.called, range(10))
+    self.assertEquals(self.called, list(range(10)))
 
   def testStopsAfterError(self):
     for i in range(10):
       self.fm.AddMerger(TestFeedMerger.Merger(self, i, i == 5))
     self.assert_(not self.fm.MergeSchedules())
-    self.assertEquals(self.called, range(6))
+    self.assertEquals(self.called, list(range(6)))
 
   def testRegister(self):
     s1 = transitfeed.Stop(stop_id='1')
@@ -467,10 +470,10 @@ class TestServicePeriodMerger(util.TestCase):
 
     self.spm.DisjoinCalendars('20080101')
 
-    self.assert_('20071201' in self.sp1.date_exceptions.keys())
-    self.assert_('20081231' not in self.sp1.date_exceptions.keys())
-    self.assert_('20071201' not in self.sp2.date_exceptions.keys())
-    self.assert_('20081231' in self.sp2.date_exceptions.keys())
+    self.assert_('20071201' in list(self.sp1.date_exceptions.keys()))
+    self.assert_('20081231' not in list(self.sp1.date_exceptions.keys()))
+    self.assert_('20071201' not in list(self.sp2.date_exceptions.keys()))
+    self.assert_('20081231' in list(self.sp2.date_exceptions.keys()))
 
   def testUnion(self):
     self._AddTwoPeriods('20071213', '20071231',
@@ -576,7 +579,7 @@ class TestAgencyMerger(util.TestCase):
     # Force a1.agency_id to be unicode to make sure it is correctly encoded
     # to utf-8 before concatinating to the agency_name containing non-ascii
     # characters.
-    self.a1.agency_id = unicode(self.a1.agency_id)
+    self.a1.agency_id = str(self.a1.agency_id)
     self.a2.agency_id = str(self.a1.agency_id)
     self.a2.agency_name = 'different \xc3\xa9'
     self.fm.a_schedule.AddAgencyObject(self.a1)

--- a/tests/testshapelib.py
+++ b/tests/testshapelib.py
@@ -17,7 +17,10 @@
 """Tests for transitfeed.shapelib.py"""
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import division
 
+from builtins import range
+from past.utils import old_div
 __author__ = 'chris.harrelson.code@gmail.com (Chris Harrelson)'
 
 import math
@@ -58,7 +61,7 @@ class ShapeLibTestBase(util.TestCase):
     except AssertionError:
       print("ERROR: %s != %s" % (formatPoints(points1), formatPoints(points2)))
       raise
-    for i in xrange(len(points1)):
+    for i in range(len(points1)):
       try:
         self.assertPointApproxEq(points1[i], points2[i])
       except AssertionError:
@@ -80,9 +83,9 @@ class TestPoints(ShapeLibTestBase):
 
     norm = 1.7320508075688772
     self.assertPointApproxEq(p.Normalize(),
-                                    Point(1 / norm,
-                                          1 / norm,
-                                          1 / norm))
+                                    Point(old_div(1, norm),
+                                          old_div(1, norm),
+                                          old_div(1, norm)))
 
     p2 = Point(1, 0, 0)
     self.assertPointApproxEq(p2, p2.Normalize())
@@ -122,7 +125,7 @@ class TestPoints(ShapeLibTestBase):
   def testAngle(self):
     point1 = Point(1, 1, 0).Normalize()
     point2 = Point(0, 1, 0)
-    self.assertApproxEq(45, point1.Angle(point2) * 360 / (2 * math.pi))
+    self.assertApproxEq(45, old_div(point1.Angle(point2) * 360, (2 * math.pi)))
     self.assertApproxEq(point1.Angle(point2), point2.Angle(point1))
 
   def testGetDistanceMeters(self):

--- a/tests/testunusual_trip_filter.py
+++ b/tests/testunusual_trip_filter.py
@@ -38,7 +38,7 @@ class UnusualTripFilterTestCase(util.TempDirTestCaseBase):
     loader = transitfeed.Loader(input, extra_validation=True)
     schedule = loader.Load()
     filter.filter(schedule)
-    for trip_id, expected_trip_type in expected_values.items():
+    for trip_id, expected_trip_type in list(expected_values.items()):
       actual_trip_type = schedule.trips[trip_id]['trip_type']
       try:
         self.assertEquals(int(actual_trip_type), expected_trip_type)

--- a/tests/transitfeed/testagency.py
+++ b/tests/transitfeed/testagency.py
@@ -150,7 +150,7 @@ class AgencyAttributesTestCase(util.ValidationTestCase):
     self.assertEquals({"agency_name": "Test Agency",
                        "agency_url": "http://example.com",
                        "agency_timezone": "America/Los_Angeles"},
-                      dict(agency.iteritems()))
+                      dict(iter(list(agency.items()))))
 
 
 class DeprecatedAgencyFieldsTestCase(util.MemoryZipTestCase):

--- a/tests/transitfeed/testgtfsfactory.py
+++ b/tests/transitfeed/testgtfsfactory.py
@@ -15,6 +15,7 @@
 # Unit tests for the gtfsfactory module.
 from __future__ import absolute_import
 
+from builtins import object
 from tests import util
 import transitfeed
 import types
@@ -124,7 +125,7 @@ class TestGtfsFactory(util.TestCase):
         "transfers.txt", "routes.txt", "trips.txt"):
       class_object = self._factory.GetGtfsClassByFileName(filename)
       self.assertTrue(isinstance(class_object,
-                                 (types.TypeType, types.ClassType)),
+                                 type),
                       "The mapping from filenames to classes must return "
                       "classes and not instances. This is not the case for " +
                       filename)

--- a/tests/transitfeed/testloader.py
+++ b/tests/transitfeed/testloader.py
@@ -15,8 +15,11 @@
 # Unit tests for the loader module.
 from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 import re
-from StringIO import StringIO
+from io import StringIO
 import tempfile
 from tests import util
 import transitfeed

--- a/tests/transitfeed/testroute.py
+++ b/tests/transitfeed/testroute.py
@@ -17,7 +17,9 @@
 # Unit tests for the route module.
 from __future__ import absolute_import
 
-from StringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+from io import StringIO
 from tests import util
 import transitfeed
 

--- a/tests/transitfeed/testschedule_write.py
+++ b/tests/transitfeed/testschedule_write.py
@@ -15,6 +15,7 @@
 # Unit tests for the schedule module.
 from __future__ import absolute_import
 
+from builtins import zip
 from tests import util
 import transitfeed
 
@@ -372,7 +373,7 @@ class WriteSampleFeedTestCase(util.TempFileTestCaseBase):
                   ("16:00:00", "16:00:00", "BEATTY_AIRPORT", None, None, None, None)],
       }
 
-    for trip_id, stop_time_list in stop_time_data.items():
+    for trip_id, stop_time_list in list(stop_time_data.items()):
       for stop_time_entry in stop_time_list:
         (arrival_time, departure_time, stop_id, shape_dist_traveled,
             pickup_type, drop_off_type, stop_headsign) = stop_time_entry
@@ -487,7 +488,7 @@ class WriteSampleFeedTestCase(util.TempFileTestCaseBase):
       self.assertEqual(headway_trips[trip_id],
                        read_schedule.GetTrip(trip_id).GetFrequencyTuples())
 
-    for trip_id, stop_time_list in stop_time_data.items():
+    for trip_id, stop_time_list in list(stop_time_data.items()):
       trip = read_schedule.GetTrip(trip_id)
       read_stoptimes = trip.GetStopTimes()
       self.assertEqual(len(read_stoptimes), len(stop_time_list))

--- a/tests/transitfeed/teststop.py
+++ b/tests/transitfeed/teststop.py
@@ -15,6 +15,8 @@
 # Unit tests for the stop module.
 from __future__ import absolute_import
 
+from builtins import str
+from past.builtins import basestring
 from tests import util
 import transitfeed
 

--- a/tests/transitfeed/teststoptime.py
+++ b/tests/transitfeed/teststoptime.py
@@ -15,6 +15,7 @@
 # Unit tests for the stoptime module.
 from __future__ import absolute_import
 
+from builtins import range
 import transitfeed
 from tests import util
 

--- a/tests/transitfeed/testtransfer.py
+++ b/tests/transitfeed/testtransfer.py
@@ -15,7 +15,9 @@
 # Unit tests for the transfer module.
 from __future__ import absolute_import
 
-from StringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+from io import StringIO
 import transitfeed
 from tests import util
 

--- a/tests/transitfeed/testtransitfeed.py
+++ b/tests/transitfeed/testtransitfeed.py
@@ -119,12 +119,12 @@ class DeprecatedFieldNamesTestCase(util.MemoryZipTestCase):
         "DTA,Demo Agency,America/Los_Angeles\n")
     schedule = self.MakeLoaderAndLoad(self.problems,
                                       gtfs_factory=self.gtfs_factory)
-    agency = schedule._agencies.values()[0]
+    agency = list(schedule._agencies.values())[0]
     self.assertTrue(agency.agency_url == None)
     # stop.txt from util.MemoryZipTestCase does not have 'stop_desc', accessing
     # the variable stop_desc should default to None instead of raising an
     # AttributeError
-    stop = schedule.stops.values()[0]
+    stop = list(schedule.stops.values())[0]
     self.assertTrue(stop.stop_desc == None)
     self.accumulator.AssertNoMoreExceptions()
 

--- a/tests/transitfeed/testtrip.py
+++ b/tests/transitfeed/testtrip.py
@@ -15,7 +15,10 @@
 # Unit tests for the trip module.
 from __future__ import absolute_import
 
-from StringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from io import StringIO
 from tests import util
 import transitfeed
 

--- a/tests/transitfeed/testutil.py
+++ b/tests/transitfeed/testutil.py
@@ -16,9 +16,13 @@
 
 # Unit tests for transitfeed/util.py
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
+from builtins import object
 import datetime
 import re
-import StringIO
+import io
 import tests.util as test_util
 from transitfeed import problems
 from transitfeed.problems import ProblemReporter
@@ -26,8 +30,8 @@ from transitfeed import stop
 from transitfeed import util
 from transitfeed import version
 import unittest
-from urllib2 import HTTPError, URLError
-import urllib2
+from urllib.error import HTTPError, URLError
+import urllib.request, urllib.error, urllib.parse
 
 
 class ColorLuminanceTestCase(test_util.TestCase):
@@ -55,7 +59,7 @@ class FindUniqueIdTestCase(test_util.TestCase):
     d = {}
     for i in range(0, 5):
       d[util.FindUniqueId(d)] = 1
-    k = d.keys()
+    k = list(d.keys())
     k.sort()
     self.assertEqual(('0', '1', '2', '3', '4'), tuple(k))
 
@@ -254,14 +258,14 @@ class NonNegIntStringToIntTestCase(test_util.TestCase):
 
 class CheckVersionTestCase(test_util.TempDirTestCaseBase):
   def setUp(self):
-    self.orig_urlopen = urllib2.urlopen
+    self.orig_urlopen = urllib.request.urlopen
     self.mock = MockURLOpen()
     self.accumulator = test_util.RecordingProblemAccumulator(self)
     self.problems = ProblemReporter(self.accumulator)
 
   def tearDown(self):
     self.mock = None
-    urllib2.urlopen = self.orig_urlopen
+    urllib.request.urlopen = self.orig_urlopen
 
   def testAssignedDifferentVersion(self):
     util.CheckVersion(self.problems, '100.100.100')
@@ -275,42 +279,42 @@ class CheckVersionTestCase(test_util.TempDirTestCaseBase):
     self.accumulator.AssertNoMoreExceptions()
 
   def testGetCorrectReturns(self):
-    urllib2.urlopen = self.mock.mockedConnectSuccess
+    urllib.request.urlopen = self.mock.mockedConnectSuccess
     util.CheckVersion(self.problems)
     self.accumulator.PopException('NewVersionAvailable')
 
   def testPageNotFound(self):
-    urllib2.urlopen = self.mock.mockedPageNotFound
+    urllib.request.urlopen = self.mock.mockedPageNotFound
     util.CheckVersion(self.problems)
     e = self.accumulator.PopException('OtherProblem')
     self.assertTrue(re.search(r'we failed to reach', e.description))
     self.assertTrue(re.search(r'Reason: Not Found \[404\]', e.description))
 
   def testConnectionTimeOut(self):
-    urllib2.urlopen = self.mock.mockedConnectionTimeOut
+    urllib.request.urlopen = self.mock.mockedConnectionTimeOut
     util.CheckVersion(self.problems)
     e = self.accumulator.PopException('OtherProblem')
     self.assertTrue(re.search(r'we failed to reach', e.description))
     self.assertTrue(re.search(r'Reason: Connection timed', e.description))
 
   def testGetAddrInfoFailed(self):
-    urllib2.urlopen = self.mock.mockedGetAddrInfoFailed
+    urllib.request.urlopen = self.mock.mockedGetAddrInfoFailed
     util.CheckVersion(self.problems)
     e = self.accumulator.PopException('OtherProblem')
     self.assertTrue(re.search(r'we failed to reach', e.description))
     self.assertTrue(re.search(r'Reason: Getaddrinfo failed', e.description))
 
   def testEmptyIsReturned(self):
-    urllib2.urlopen = self.mock.mockedEmptyIsReturned
+    urllib.request.urlopen = self.mock.mockedEmptyIsReturned
     util.CheckVersion(self.problems)
     e = self.accumulator.PopException('OtherProblem')
     self.assertTrue(re.search(r'we had trouble parsing', e.description))
 
 
-class MockURLOpen:
+class MockURLOpen(object):
   """Pretend to be a urllib2.urlopen suitable for testing."""
   def mockedConnectSuccess(self, request):
-    return StringIO.StringIO('latest_version=100.0.1')
+    return io.StringIO('latest_version=100.0.1')
 
   def mockedPageNotFound(self, request):
     raise HTTPError(request.get_full_url(), 404, 'Not Found',
@@ -323,7 +327,7 @@ class MockURLOpen:
     raise URLError('Getaddrinfo failed')
 
   def mockedEmptyIsReturned(self, request):
-    return StringIO.StringIO()
+    return io.StringIO()
 
 
 if __name__ == '__main__':

--- a/tests/util.py
+++ b/tests/util.py
@@ -199,7 +199,7 @@ class TempDirTestCaseBase(GetPathTestCase):
         The new file's in-memory contents as a file-like object."""
     zipfile_mem = StringIO()
     zip = zipfile.ZipFile(zipfile_mem, 'a')
-    for arcname, contents in dict.items():
+    for arcname, contents in list(dict.items()):
       zip.writestr(arcname, contents)
     zip.close()
     return zipfile_mem
@@ -315,13 +315,13 @@ class MemoryZipTestCase(TestCase):
 
   def GetArchiveNames(self):
     """Get a list of all the archive names in the file dict."""
-    return self.zip_contents.keys()
+    return list(self.zip_contents.keys())
 
   def CreateZip(self):
     """Create an in-memory GTFS zipfile from the contents of the file dict."""
     self.zipfile = StringIO()
     self.zip = zipfile.ZipFile(self.zipfile, 'a')
-    for (arcname, contents) in self.zip_contents.items():
+    for (arcname, contents) in list(self.zip_contents.items()):
       self.zip.writestr(arcname, contents)
 
   def DumpZipFile(self, zf):

--- a/transitfeed/compat.py
+++ b/transitfeed/compat.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
 try:  # py2
-  from StringIO import StringIO
+  from io import StringIO
 except ImportError:
   from io import StringIO

--- a/transitfeed/fareattribute.py
+++ b/transitfeed/fareattribute.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from builtins import range
 from .gtfsobjectbase import GtfsObjectBase
 from .problems import default_problem_reporter
 from . import util
@@ -40,7 +41,7 @@ class FareAttribute(GtfsObjectBase):
       if isinstance(field_dict, FareAttribute):
         # Special case so that we don't need to re-parse the attributes to
         # native types iteritems returns all attributes that don't start with _
-        for k, v in field_dict.iteritems():
+        for k, v in list(field_dict.items()):
           self.__dict__[k] = v
       else:
         self.__dict__.update(field_dict)
@@ -122,7 +123,7 @@ class FareAttribute(GtfsObjectBase):
     if self.payment_method == "" or self.payment_method == None:
       problems.MissingValue("payment_method")
     elif (not isinstance(self.payment_method, int) or
-          self.payment_method not in range(0, 2)):
+          self.payment_method not in list(range(0, 2))):
       problems.InvalidValue("payment_method", self.payment_method)
 
   def ValidateTransfers(self, problems):

--- a/transitfeed/farerule.py
+++ b/transitfeed/farerule.py
@@ -39,7 +39,7 @@ class FareRule(GtfsObjectBase):
       if isinstance(field_dict, self.GetGtfsFactory().FareRule):
         # Special case so that we don't need to re-parse the attributes to
         # native types iteritems returns all attributes that don't start with _
-        for k, v in field_dict.iteritems():
+        for k, v in list(field_dict.items()):
           self.__dict__[k] = v
       else:
         self.__dict__.update(field_dict)

--- a/transitfeed/frequency.py
+++ b/transitfeed/frequency.py
@@ -31,7 +31,7 @@ class Frequency(GtfsObjectBase):
       self._schedule = None
       if field_dict:
         if isinstance(field_dict, self.__class__):
-          for k, v in field_dict.iteritems():
+          for k, v in list(field_dict.items()):
             self.__dict__[k] = v
         else:
           self.__dict__.update(field_dict)

--- a/transitfeed/gtfsfactory.py
+++ b/transitfeed/gtfsfactory.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from builtins import object
 from .agency import Agency
 from .fareattribute import FareAttribute
 from .farerule import FareRule
@@ -128,7 +129,7 @@ class GtfsFactory(object):
     """Returns a list of filenames sorted by loading order.
     Only includes files that Loader's standardized loading knows how to load"""
     result = {}
-    for filename, mapping in self._file_mapping.iteritems():
+    for filename, mapping in list(self._file_mapping.items()):
       loading_order = mapping['loading_order']
       if loading_order is not None:
         result[loading_order] = filename
@@ -144,7 +145,7 @@ class GtfsFactory(object):
 
   def GetKnownFilenames(self):
     """Returns a list of all known filenames"""
-    return self._file_mapping.keys()
+    return list(self._file_mapping.keys())
 
   def RemoveMapping(self, filename):
     """Removes an entry from the list of known filenames.

--- a/transitfeed/gtfsfactoryuser.py
+++ b/transitfeed/gtfsfactoryuser.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from builtins import object
 class GtfsFactoryUser(object):
   """Base class for objects that must store a GtfsFactory in order to
      be able to instantiate Gtfs classes.

--- a/transitfeed/gtfsobjectbase.py
+++ b/transitfeed/gtfsobjectbase.py
@@ -69,7 +69,7 @@ class GtfsObjectBase(GtfsFactoryUser):
 
   def iteritems(self):
     """Return a iterable for (name, value) pairs of public attributes."""
-    for name, value in self.__dict__.iteritems():
+    for name, value in list(self.__dict__.items()):
       if (not name) or name[0] == "_":
         continue
       yield name, value
@@ -88,7 +88,7 @@ class GtfsObjectBase(GtfsFactoryUser):
     if id(self) == id(other):
       return True
 
-    for k in self.keys().union(other.keys()):
+    for k in list(self.keys()).union(list(other.keys())):
       # use __getitem__ which returns "" for missing columns values
       if self[k] != other[k]:
         return False
@@ -103,7 +103,7 @@ class GtfsObjectBase(GtfsFactoryUser):
   # can't be fixed until the merger is changed to not use a/b_merge_map.
 
   def __repr__(self):
-    return "<%s %s>" % (self.__class__.__name__, sorted(self.iteritems()))
+    return "<%s %s>" % (self.__class__.__name__, sorted(self.items()))
 
   def keys(self):
     """Return iterable of columns used by this object."""
@@ -115,7 +115,7 @@ class GtfsObjectBase(GtfsFactoryUser):
     return columns
 
   def _ColumnNames(self):
-    return self.keys()
+    return list(self.keys())
 
   def AddToSchedule(self, schedule, problems):
     self._schedule = schedule

--- a/transitfeed/loader.py
+++ b/transitfeed/loader.py
@@ -24,12 +24,18 @@ import codecs
 import csv
 import os
 import re
+import sys
 import zipfile
 
 from . import gtfsfactoryuser
 from . import problems
 from . import util
-from .compat import StringIO
+
+if sys.version_info[0] >= 3:
+  from .compat import StringIO
+else:
+  from io import BytesIO as StringIO
+
 
 class Loader(object):
   def __init__(self,

--- a/transitfeed/loader.py
+++ b/transitfeed/loader.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from builtins import next
+from builtins import zip
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 import codecs
 import csv
 import os
@@ -26,7 +31,7 @@ from . import problems
 from . import util
 from .compat import StringIO
 
-class Loader:
+class Loader(object):
   def __init__(self,
                feed_path=None,
                schedule=None,
@@ -185,7 +190,7 @@ class Loader:
       valid_columns.append(i)
       header_occurrences[h_stripped] += 1
 
-    for name, count in header_occurrences.items():
+    for name, count in list(header_occurrences.items()):
       if count > 1:
         self._problems.DuplicateColumn(
             header=name,
@@ -276,7 +281,7 @@ class Loader:
       # of both the Google and OneBusAway GTFS parser.
       valid_values = [value.strip() for value in valid_values]
 
-      d = dict(zip(header, valid_values))
+      d = dict(list(zip(header, valid_values)))
       yield (d, line_num, header, valid_values)
 
   # TODO: Add testing for this specific function
@@ -292,12 +297,12 @@ class Loader:
     reader = csv.reader(eol_checker)  # Use excel dialect
 
     header = next(reader)
-    header = map(lambda x: x.strip(), header)  # trim any whitespace
+    header = [x.strip() for x in header]  # trim any whitespace
     header_occurrences = util.defaultdict(lambda: 0)
     for column_header in header:
       header_occurrences[column_header] += 1
 
-    for name, count in header_occurrences.items():
+    for name, count in list(header_occurrences.items()):
       if count > 1:
         self._problems.DuplicateColumn(
             header=name,
@@ -485,7 +490,7 @@ class Loader:
 
     # Now insert the periods into the schedule object, so that they're
     # validated with both calendar and calendar_dates info present
-    for period, context in periods.values():
+    for period, context in list(periods.values()):
       self._problems.SetFileContext(*context)
       self._schedule.AddServicePeriodObject(period, self._problems)
       self._problems.ClearContext()
@@ -520,7 +525,7 @@ class Loader:
       shape.AddShapePointObjectUnsorted(shapepoint, self._problems)
       self._problems.ClearContext()
 
-    for shape_id, shape in shapes.items():
+    for shape_id, shape in list(shapes.items()):
       self._schedule.AddShapeObject(shape, self._problems)
       del shapes[shape_id]
 

--- a/transitfeed/problems.py
+++ b/transitfeed/problems.py
@@ -16,6 +16,9 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from past.builtins import cmp
+from builtins import zip
+from builtins import object
 from functools import reduce
 import logging
 import time
@@ -445,7 +448,7 @@ class ExceptionWithContext(Exception):
   def GetDictToFormat(self):
     """Return a copy of self as a dict, suitable for passing to FormatProblem"""
     d = {}
-    for k, v in self.__dict__.items():
+    for k, v in list(self.__dict__.items()):
       # TODO: Better handling of unicode/utf-8 within Schedule objects.
       # Concatinating a unicode and utf-8 str object causes an exception such
       # as "UnicodeDecodeError: 'ascii' codec can't decode byte ..." as python

--- a/transitfeed/route.py
+++ b/transitfeed/route.py
@@ -41,7 +41,7 @@ class Route(GtfsObjectBase):
     }
   # Create a reverse lookup dict of route type names to route types.
   _ROUTE_TYPE_IDS = set(_ROUTE_TYPES.keys())
-  _ROUTE_TYPE_NAMES = dict((v['name'], k) for k, v in _ROUTE_TYPES.items())
+  _ROUTE_TYPE_NAMES = dict((v['name'], k) for k, v in list(_ROUTE_TYPES.items()))
   _TABLE_NAME = 'routes'
 
   def __init__(self, short_name=None, long_name=None, route_type=None,

--- a/transitfeed/schedule.py
+++ b/transitfeed/schedule.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from builtins import zip
+from builtins import str
+from builtins import range
+from builtins import object
 import bisect
 import datetime
 import itertools
@@ -148,10 +152,10 @@ class Schedule(object):
     cursor.execute("""CREATE INDEX stop_index ON stop_times (stop_id);""")
 
   def GetStopBoundingBox(self):
-    return (min(s.stop_lat for s in self.stops.values()),
-            min(s.stop_lon for s in self.stops.values()),
-            max(s.stop_lat for s in self.stops.values()),
-            max(s.stop_lon for s in self.stops.values()),
+    return (min(s.stop_lat for s in list(self.stops.values())),
+            min(s.stop_lon for s in list(self.stops.values())),
+            max(s.stop_lat for s in list(self.stops.values())),
+            max(s.stop_lon for s in list(self.stops.values())),
            )
 
   def AddAgency(self, name, url, timezone, agency_id=None):
@@ -191,7 +195,7 @@ class Schedule(object):
       if len(self._agencies) == 0:
         self.NewDefaultAgency()
       elif len(self._agencies) == 1:
-        self._default_agency = self._agencies.values()[0]
+        self._default_agency = list(self._agencies.values())[0]
     return self._default_agency
 
   def NewDefaultAgency(self, **kwargs):
@@ -212,7 +216,7 @@ class Schedule(object):
 
   def GetAgencyList(self):
     """Returns the list of Agency objects known to this Schedule."""
-    return self._agencies.values()
+    return list(self._agencies.values())
 
   def GetServicePeriod(self, service_id):
     """Returns the ServicePeriod object with the given ID."""
@@ -228,7 +232,7 @@ class Schedule(object):
       if len(self.service_periods) == 0:
         self.NewDefaultServicePeriod()
       elif len(self.service_periods) == 1:
-        self._default_service_period = self.service_periods.values()[0]
+        self._default_service_period = list(self.service_periods.values())[0]
     return self._default_service_period
 
   def NewDefaultServicePeriod(self):
@@ -261,7 +265,7 @@ class Schedule(object):
     self.service_periods[service_period.service_id] = service_period
 
   def GetServicePeriodList(self):
-    return self.service_periods.values()
+    return list(self.service_periods.values())
 
   def GetDateRange(self):
     """Returns a tuple of (earliest, latest) dates on which the service periods
@@ -281,14 +285,14 @@ class Schedule(object):
     """
     period_list = self.GetServicePeriodList()
     ranges = [period.GetDateRange() for period in period_list]
-    starts = filter(lambda x: x, [item[0] for item in ranges])
-    ends = filter(lambda x: x, [item[1] for item in ranges])
+    starts = [x for x in [item[0] for item in ranges] if x]
+    ends = [x for x in [item[1] for item in ranges] if x]
 
     if not starts or not ends:
       return (None, None, None, None)
 
-    minvalue, minindex = min(itertools.izip(starts, itertools.count()))
-    maxvalue, maxindex = max(itertools.izip(ends, itertools.count()))
+    minvalue, minindex = min(list(zip(starts, itertools.count())))
+    maxvalue, maxindex = max(list(zip(ends, itertools.count())))
 
     minreason = (period_list[minindex].HasDateExceptionOn(minvalue) and
                  "earliest service exception date in calendar_dates.txt" or
@@ -375,7 +379,7 @@ class Schedule(object):
       self.fare_zones[stop.zone_id] = True
 
   def GetStopList(self):
-    return self.stops.values()
+    return list(self.stops.values())
 
   def AddRoute(self, short_name, long_name, route_type, route_id=None):
     """Add a route to this schedule.
@@ -418,7 +422,7 @@ class Schedule(object):
     self.routes[route.route_id] = route
 
   def GetRouteList(self):
-    return self.routes.values()
+    return list(self.routes.values())
 
   def GetRoute(self, route_id):
     return self.routes[route_id]
@@ -436,7 +440,7 @@ class Schedule(object):
     self._shapes[shape.shape_id] = shape
 
   def GetShapeList(self):
-    return self._shapes.values()
+    return list(self._shapes.values())
 
   def GetShape(self, shape_id):
     return self._shapes[shape_id]
@@ -467,7 +471,7 @@ class Schedule(object):
       pass
 
   def GetTripList(self):
-    return self.trips.values()
+    return list(self.trips.values())
 
   def GetTrip(self, trip_id):
     return self.trips[trip_id]
@@ -498,7 +502,7 @@ class Schedule(object):
     return self.GetFareAttributeList()
 
   def GetFareAttributeList(self):
-    return self.fares.values()
+    return list(self.fares.values())
 
   def GetFare(self, fare_id):
     """Deprecated. Please use GetFareAttribute instead"""
@@ -567,7 +571,7 @@ class Schedule(object):
 
   def GetTransferIter(self):
     """Return an iterator for all Transfer objects in this schedule."""
-    return itertools.chain(*self._transfers.values())
+    return itertools.chain(*list(self._transfers.values()))
 
   def GetTransferList(self):
     """Return a list containing all Transfer objects in this schedule."""
@@ -579,12 +583,12 @@ class Schedule(object):
   def GetFareZones(self):
     """Returns the list of all fare zones that have been identified by
     the stops that have been added."""
-    return self.fare_zones.keys()
+    return list(self.fare_zones.keys())
 
   def GetNearestStops(self, lat, lon, n=1):
     """Return the n nearest stops to lat,lon"""
     dist_stop_list = []
-    for s in self.stops.values():
+    for s in list(self.stops.values()):
       # TODO: Use util.ApproximateDistanceBetweenStops?
       dist = (s.stop_lat - lat)**2 + (s.stop_lon - lon)**2
       if len(dist_stop_list) < n:
@@ -597,7 +601,7 @@ class Schedule(object):
   def GetStopsInBoundingBox(self, north, east, south, west, n):
     """Return a sample of up to n stops in a bounding box"""
     stop_list = []
-    for s in self.stops.values():
+    for s in list(self.stops.values()):
       if (s.stop_lat <= north and s.stop_lat >= south and
           s.stop_lon <= east and s.stop_lon >= west):
         stop_list.append(s)
@@ -637,7 +641,7 @@ class Schedule(object):
       writer = util.CsvUnicodeWriter(agency_string)
       columns = self.GetTableColumns('agency')
       writer.writerow(columns)
-      for a in self._agencies.values():
+      for a in list(self._agencies.values()):
         writer.writerow([util.EncodeUnicode(a[c]) for c in columns])
       self._WriteArchiveString(archive, 'agency.txt', agency_string)
 
@@ -655,7 +659,7 @@ class Schedule(object):
     writer.writerow(
         self._gtfs_factory.ServicePeriod._FIELD_NAMES_CALENDAR_DATES)
     has_data = False
-    for period in self.service_periods.values():
+    for period in list(self.service_periods.values()):
       for row in period.GenerateCalendarDatesFieldValuesTuples():
         has_data = True
         writer.writerow(row)
@@ -669,7 +673,7 @@ class Schedule(object):
     writer = util.CsvUnicodeWriter(calendar_string)
     writer.writerow(self._gtfs_factory.ServicePeriod._FIELD_NAMES)
     has_data = False
-    for s in self.service_periods.values():
+    for s in list(self.service_periods.values()):
       row = s.GetCalendarFieldValuesTuple()
       if row:
         has_data = True
@@ -682,7 +686,7 @@ class Schedule(object):
       writer = util.CsvUnicodeWriter(stop_string)
       columns = self.GetTableColumns('stops')
       writer.writerow(columns)
-      for s in self.stops.values():
+      for s in list(self.stops.values()):
         writer.writerow([util.EncodeUnicode(s[c]) for c in columns])
       self._WriteArchiveString(archive, 'stops.txt', stop_string)
 
@@ -691,7 +695,7 @@ class Schedule(object):
       writer = util.CsvUnicodeWriter(route_string)
       columns = self.GetTableColumns('routes')
       writer.writerow(columns)
-      for r in self.routes.values():
+      for r in list(self.routes.values()):
         writer.writerow([util.EncodeUnicode(r[c]) for c in columns])
       self._WriteArchiveString(archive, 'routes.txt', route_string)
 
@@ -700,7 +704,7 @@ class Schedule(object):
       writer = util.CsvUnicodeWriter(trips_string)
       columns = self.GetTableColumns('trips')
       writer.writerow(columns)
-      for t in self.trips.values():
+      for t in list(self.trips.values()):
         writer.writerow([util.EncodeUnicode(t[c]) for c in columns])
       self._WriteArchiveString(archive, 'trips.txt', trips_string)
 
@@ -738,7 +742,7 @@ class Schedule(object):
     stop_times_string = StringIO()
     writer = util.CsvUnicodeWriter(stop_times_string)
     writer.writerow(self._gtfs_factory.StopTime._FIELD_NAMES)
-    for t in self.trips.values():
+    for t in list(self.trips.values()):
       writer.writerows(t._GenerateStopTimesTuples())
     self._WriteArchiveString(archive, 'stop_times.txt', stop_times_string)
 
@@ -804,8 +808,7 @@ class Schedule(object):
     return date_trips
 
   def ValidateAgenciesHaveSameAgencyTimezone(self, problems):
-    timezones_set = set(map(lambda agency:agency.agency_timezone,
-                            self.GetAgencyList()))
+    timezones_set = set([agency.agency_timezone for agency in self.GetAgencyList()])
     if len(timezones_set) > 1:
       timezones_str = '"%s"' % ('", "'.join(timezones_set))
       problems.InvalidValue('agency_timezone', timezones_str,
@@ -981,7 +984,7 @@ class Schedule(object):
     # Check for stops that aren't referenced by any trips and broken
     # parent_station references. Also check that the parent station isn't too
     # far from its child stops.
-    for stop in self.stops.values():
+    for stop in list(self.stops.values()):
       if validate_children:
         stop.Validate(problems)
       cursor = self._connection.cursor()
@@ -1029,8 +1032,7 @@ class Schedule(object):
     # each pair of stations within 2 meters latitude of each other. This avoids
     # doing n^2 comparisons in the average case and doesn't need a spatial
     # index.
-    sorted_stops = filter(lambda s: s.stop_lat and s.stop_lon,
-                          self.GetStopList())
+    sorted_stops = [s for s in self.GetStopList() if s.stop_lat and s.stop_lon]
     sorted_stops.sort(
         key=(lambda x: [x.stop_lat, x.stop_lon, getattr(x, 'stop_id', None)]))
     TWO_METERS_LAT = 0.000018
@@ -1073,7 +1075,7 @@ class Schedule(object):
   def ValidateRouteNames(self, problems, validate_children):
     # Check for multiple routes using same short + long name
     route_names = {}
-    for route in self.routes.values():
+    for route in list(self.routes.values()):
       if validate_children:
         route.Validate(problems)
       short_name = ''
@@ -1210,7 +1212,7 @@ class Schedule(object):
     # Cache potentially expensive ServicePeriod overlap checks
     service_period_overlap_cache = {}
 
-    for (block_id,trip_intervals) in trip_intervals_by_block_id.items():
+    for (block_id,trip_intervals) in list(trip_intervals_by_block_id.items()):
 
       # Sort trip intervals by min arrival time
       trip_intervals.sort(key=(lambda x: x[1]))
@@ -1281,7 +1283,7 @@ class Schedule(object):
   def ValidateIdlessAgency(self, problems):
     # Check that only one agency is IDless
     if len(self._agencies) > 1:
-      for agency in self._agencies.values():
+      for agency in list(self._agencies.values()):
         if util.IsEmpty(agency.agency_id):
           problems.OtherProblem('Agency "%s" does not have an ID. '
                                 'This is only allowed if a single agency is defined, '
@@ -1289,7 +1291,7 @@ class Schedule(object):
 
   def ValidateRouteAgencyId(self, problems):
     # Check that routes' agency IDs are valid, if set
-    for route in self.routes.values():
+    for route in list(self.routes.values()):
       if (not util.IsEmpty(route.agency_id) and
           not route.agency_id in self._agencies):
         problems.InvalidAgencyID('agency_id', route.agency_id,
@@ -1299,7 +1301,7 @@ class Schedule(object):
     # Make sure all trips have stop_times
     # We're doing this here instead of in Trip.Validate() so that
     # Trips can be validated without error during the reading of trips.txt
-    for trip in self.trips.values():
+    for trip in list(self.trips.values()):
       trip.ValidateChildren(problems)
       count_stop_times = trip.GetCountStopTimes()
       if not count_stop_times:

--- a/transitfeed/serviceperiod.py
+++ b/transitfeed/serviceperiod.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from builtins import str
+from builtins import range
+from builtins import object
 import datetime
 import re
 import time
@@ -89,7 +92,7 @@ class ServicePeriod(object):
     start = self.start_date
     end = self.end_date
 
-    for date, (exception_type, _) in self.date_exceptions.items():
+    for date, (exception_type, _) in list(self.date_exceptions.items()):
       if exception_type == self._EXCEPTION_TYPE_REMOVE:
         continue
       if not start or (date < start):
@@ -112,8 +115,8 @@ class ServicePeriod(object):
   def GenerateCalendarDatesFieldValuesTuples(self):
     """Generates tuples of calendar_dates.txt values. Yield zero tuples if
     this ServicePeriod should not be in calendar_dates.txt ."""
-    for date, (exception_type, _) in self.date_exceptions.items():
-      yield (self.service_id, date, unicode(exception_type))
+    for date, (exception_type, _) in list(self.date_exceptions.items()):
+      yield (self.service_id, date, str(exception_type))
 
   def GetCalendarDatesFieldValuesTuples(self):
     """Return a list of date execeptions"""
@@ -306,13 +309,13 @@ class ServicePeriod(object):
                             type=problems_module.TYPE_WARNING)
 
   def HasDateExceptionTypeAdded(self):
-    for exception_type, _ in self.date_exceptions.values():
+    for exception_type, _ in list(self.date_exceptions.values()):
       if exception_type == self._EXCEPTION_TYPE_ADD:
         return True
     return False
 
   def ValidateDates(self, problems):
-    for date, (exception_type, context) in self.date_exceptions.items():
+    for date, (exception_type, context) in list(self.date_exceptions.items()):
       self.ValidateDate(date, 'date', problems, context)
 
   def ValidateDate(self, date, field_name, problems, context=None):

--- a/transitfeed/shape.py
+++ b/transitfeed/shape.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from __future__ import division
+from past.utils import old_div
 import bisect
 
 from .gtfsfactoryuser import GtfsFactoryUser
@@ -165,6 +167,6 @@ class Shape(GtfsFactoryUser):
       return None
     # This won't work crossing longitude 180 and is only an approximation which
     # works well for short distance.
-    lat = (lat1 * ca + lat0 * bc) / ba
-    lng = (lng1 * ca + lng0 * bc) / ba
+    lat = old_div((lat1 * ca + lat0 * bc), ba)
+    lng = old_div((lng1 * ca + lng0 * bc), ba)
     return (lat, lng, shape_dist_traveled)

--- a/transitfeed/shapelib.py
+++ b/transitfeed/shapelib.py
@@ -29,7 +29,13 @@ is adequate; for other purposes, this library may not be accurate
 enough.
 """
 from __future__ import print_function
+from __future__ import division
 
+from past.builtins import cmp
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 __author__ = 'chris.harrelson.code@gmail.com (Chris Harrelson)'
 
 import copy
@@ -109,7 +115,7 @@ class Point(object):
     """
     Returns a unit point in the same direction as self.
     """
-    return self.Times(1 / self.Norm2())
+    return self.Times(old_div(1, self.Norm2()))
 
   def RobustCrossProd(self, other):
     """
@@ -230,7 +236,7 @@ def GetClosestPoint(x, a, b):
   # project to the great circle going through a and b
   p = x.Minus(
       a_cross_b.Times(
-      x.DotProd(a_cross_b) / a_cross_b.Norm2()))
+      old_div(x.DotProd(a_cross_b), a_cross_b.Norm2())))
 
   # if p lies between a and b, return it
   if SimpleCCW(a_cross_b, a, p) and SimpleCCW(p, b, a_cross_b):
@@ -416,7 +422,7 @@ class PolyCollection(object):
     within max_radius of the given start and end points.
     """
     matches = []
-    for shape in self._name_to_shape.itervalues():
+    for shape in list(self._name_to_shape.values()):
       if start_point.GetDistanceMeters(shape.GetPoint(0)) < max_radius and \
         end_point.GetDistanceMeters(shape.GetPoint(-1)) < max_radius:
         matches.append(shape)
@@ -540,7 +546,7 @@ class PolyGraph(PolyCollection):
     paths_found = [] # A heap sorted by inverse path length.
 
     for i, point in enumerate(points):
-      nearby = [p for p in self._nodes.iterkeys()
+      nearby = [p for p in list(self._nodes.keys())
                 if p.GetDistanceMeters(point) < max_radius]
       if verbosity >= 2:
         print ("Nearby points for point %d %s: %s"

--- a/transitfeed/shapepoint.py
+++ b/transitfeed/shapepoint.py
@@ -45,7 +45,7 @@ class ShapePoint(GtfsObjectBase):
     self._schedule = None
     if field_dict:
       if isinstance(field_dict, self.__class__):
-        for k, v in field_dict.iteritems():
+        for k, v in list(field_dict.items()):
           self.__dict__[k] = v
       else:
         self.__dict__.update(field_dict)

--- a/transitfeed/stop.py
+++ b/transitfeed/stop.py
@@ -62,7 +62,7 @@ class Stop(GtfsObjectBase):
       if isinstance(field_dict, self.__class__):
         # Special case so that we don't need to re-parse the attributes to
         # native types iteritems returns all attributes that don't start with _
-        for k, v in field_dict.iteritems():
+        for k, v in list(field_dict.items()):
           self.__dict__[k] = v
       else:
         self.__dict__.update(field_dict)

--- a/transitfeed/stoptime.py
+++ b/transitfeed/stoptime.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 
+from builtins import object
 from . import problems as problems_module
 from .stop import Stop
 from . import util

--- a/transitfeed/transfer.py
+++ b/transitfeed/transfer.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 from .gtfsobjectbase import GtfsObjectBase
 from . import problems as problems_module
 from . import util
@@ -74,7 +77,7 @@ class Transfer(GtfsObjectBase):
   def ValidateTransferType(self, problems):
     if not util.IsEmpty(self.transfer_type):
       if (not isinstance(self.transfer_type, int)) or \
-          (self.transfer_type not in range(0, 4)):
+          (self.transfer_type not in list(range(0, 4))):
         problems.InvalidValue('transfer_type', self.transfer_type)
         return False
     return True
@@ -120,13 +123,13 @@ class Transfer(GtfsObjectBase):
     return distance
 
   def ValidateFromStopIdIsValid(self, problems):
-    if self.from_stop_id not in self._schedule.stops.keys():
+    if self.from_stop_id not in list(self._schedule.stops.keys()):
       problems.InvalidValue('from_stop_id', self.from_stop_id)
       return False
     return True
 
   def ValidateToStopIdIsValid(self, problems):
-    if self.to_stop_id not in self._schedule.stops.keys():
+    if self.to_stop_id not in list(self._schedule.stops.keys()):
       problems.InvalidValue('to_stop_id', self.to_stop_id)
       return False
     return True
@@ -160,7 +163,7 @@ class Transfer(GtfsObjectBase):
     # Stops that are close together (less than 240m appart) never trigger this
     # warning, regardless of min_transfer_time.
     FAST_WALKING_SPEED= 2 # 2m/s
-    if self.min_transfer_time + 120 < distance / FAST_WALKING_SPEED:
+    if self.min_transfer_time + 120 < old_div(distance, FAST_WALKING_SPEED):
       problems.TransferWalkingSpeedTooFast(from_stop_id=self.from_stop_id,
                                            to_stop_id=self.to_stop_id,
                                            transfer_time=self.min_transfer_time,

--- a/transitfeed/trip.py
+++ b/transitfeed/trip.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from __future__ import division
+from builtins import str
+from past.builtins import basestring
+from past.utils import old_div
 import warnings
 
 from .gtfsobjectbase import GtfsObjectBase
@@ -208,7 +212,7 @@ class Trip(GtfsObjectBase):
         rv.append( (st.GetTimeSecs(), st, True) )
       else:
         distance_traveled_between_timepoints += util.ApproximateDistanceBetweenStops(stoptimes[i-1].stop, st.stop)
-        distance_percent = distance_traveled_between_timepoints / distance_between_timepoints
+        distance_percent = old_div(distance_traveled_between_timepoints, distance_between_timepoints)
         total_time = next_timepoint.GetTimeSecs() - cur_timepoint.GetTimeSecs()
         time_estimate = distance_percent * total_time + cur_timepoint.GetTimeSecs()
         rv.append( (int(round(time_estimate)), st, False) )
@@ -477,8 +481,8 @@ class Trip(GtfsObjectBase):
       return (self.trip_id,
               util.FormatSecondsSinceMidnight(headway[0]),
               util.FormatSecondsSinceMidnight(headway[1]),
-              unicode(headway[2]),
-              unicode(headway[3]))
+              str(headway[2]),
+              str(headway[3]))
 
   def GetFrequencyOutputTuples(self):
     tuples = []
@@ -738,7 +742,7 @@ class Trip(GtfsObjectBase):
         # https://github.com/google/transitfeed/issues/193
         # Show a warning if times are not rounded to the nearest minute or
         # distance is more than max_speed for one minute.
-        if depart_time % 60 != 0 or dist_between_stops / 1000 * 60 > max_speed:
+        if depart_time % 60 != 0 or old_div(dist_between_stops, 1000) * 60 > max_speed:
           problems.TooFastTravel(self.trip_id,
                                  prev_stop.stop_name,
                                  next_stop.stop_name,
@@ -748,8 +752,8 @@ class Trip(GtfsObjectBase):
                                  type=problems_module.TYPE_WARNING)
         return
       # This needs floating point division for precision.
-      speed_between_stops = ((float(dist_between_stops) / 1000) /
-                                (float(time_between_stops) / 3600))
+      speed_between_stops = (old_div((float(dist_between_stops) / 1000),
+                                (float(time_between_stops) / 3600)))
       if speed_between_stops > max_speed:
         problems.TooFastTravel(self.trip_id,
                                prev_stop.stop_name,

--- a/transitfeed/util.py
+++ b/transitfeed/util.py
@@ -16,6 +16,15 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import input
+from builtins import next
+from builtins import str
+from past.builtins import basestring
+from builtins import object
+from past.utils import old_div
 import codecs
 import csv
 import datetime
@@ -26,7 +35,7 @@ import re
 import socket
 import sys
 import time
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 from . import errors
 from .version import __version__
@@ -89,7 +98,7 @@ or an email to the public group transitfeed@googlegroups.com. Sorry!
             dump.append(' --> %s' % line)
           else:
             dump.append('     %s' % line)
-      for local_name, local_val in frame_obj.f_locals.items():
+      for local_name, local_val in list(frame_obj.f_locals.items()):
         try:
           truncated_val = str(local_val)[0:500]
         except Exception as e:
@@ -110,7 +119,7 @@ or an email to the public group transitfeed@googlegroups.com. Sorry!
     print(apology)
 
     try:
-      raw_input('Press enter to continue...')
+      input('Press enter to continue...')
     except EOFError:
       # Ignore stdin being closed. This happens during some tests.
       pass
@@ -164,7 +173,7 @@ except:
         args = tuple()
       else:
         args = self.default_factory,
-      return type(self), args, None, None, self.items()
+      return type(self), args, None, None, list(self.items())
     def copy(self):
       return self.__copy__()
     def __copy__(self):
@@ -172,7 +181,7 @@ except:
     def __deepcopy__(self, memo):
       import copy
       return type(self)(self.default_factory,
-                        copy.deepcopy(self.items()))
+                        copy.deepcopy(list(self.items())))
     def __repr__(self):
       return 'defaultdict(%s, %s)' % (self.default_factory,
                                       dict.__repr__(self))
@@ -190,23 +199,23 @@ def CheckVersion(problems, latest_version=None):
   if not latest_version:
     timeout = 20
     socket.setdefaulttimeout(timeout)
-    request = urllib2.Request(LATEST_RELEASE_VERSION_URL)
+    request = urllib.request.Request(LATEST_RELEASE_VERSION_URL)
 
     try:
-      response = urllib2.urlopen(request)
+      response = urllib.request.urlopen(request)
       content = response.read()
       m = re.search(r'version=(\d+\.\d+\.\d+)', content)
       if m:
         latest_version = m.group(1)
 
-    except urllib2.HTTPError as e:
+    except urllib.error.HTTPError as e:
       description = ('During the new-version check, we failed to reach '
                      'transitfeed server: Reason: %s [%s].' %
                      (e.reason, e.code))
       problems.OtherProblem(
         description=description, type=errors.TYPE_NOTICE)
       return
-    except urllib2.URLError as e:
+    except urllib.error.URLError as e:
       description = ('During the new-version check, we failed to reach '
                      'transitfeed server. Reason: %s.' % e.reason)
       problems.OtherProblem(
@@ -468,7 +477,7 @@ def TimeToSecondsSinceMidnight(time_string):
 def FormatSecondsSinceMidnight(s):
   """Formats an int number of seconds past midnight into a string
   as "HH:MM:SS"."""
-  return "%02d:%02d:%02d" % (s / 3600, (s / 60) % 60, s % 60)
+  return "%02d:%02d:%02d" % (old_div(s, 3600), (old_div(s, 60)) % 60, s % 60)
 
 def DateStringToDateObject(date_string):
   """Return a date object for a string "YYYYMMDD"."""
@@ -538,7 +547,7 @@ def ApproximateDistanceBetweenStops(stop1, stop2):
   return ApproximateDistance(stop1.stop_lat, stop1.stop_lon,
                              stop2.stop_lat, stop2.stop_lon)
 
-class CsvUnicodeWriter:
+class CsvUnicodeWriter(object):
   """
   Create a wrapper around a csv writer object which can safely write unicode
   values. Passes all arguments to csv.writer.
@@ -551,7 +560,7 @@ class CsvUnicodeWriter:
     utf-8."""
     encoded_row = []
     for s in row:
-      if isinstance(s, unicode):
+      if isinstance(s, str):
         encoded_row.append(s.encode("utf-8"))
       else:
         encoded_row.append(s)
@@ -581,7 +590,7 @@ INVALID_LINE_SEPARATOR_UTF8 = {
     "\xc2\x85": "Unicode NEXT LINE SEPARATOR U+0085",
 }
 
-class EndOfLineChecker:
+class EndOfLineChecker(object):
   """Wrapper for a file-like object that checks for consistent line ends.
 
   The check for consistent end of lines (all CR LF or all LF) only happens if
@@ -607,7 +616,7 @@ class EndOfLineChecker:
   def __iter__(self):
     return self
 
-  def next(self):
+  def __next__(self):
     """Return next line without end of line marker or raise StopIteration."""
     try:
       next_line = next(self._f)
@@ -638,7 +647,7 @@ class EndOfLineChecker:
         codecs.getencoder('string_escape')(m_eol.group())[0],
         (self._name, self._line_number))
     next_line_contents = next_line[0:m_eol.start()]
-    for seq, name in INVALID_LINE_SEPARATOR_UTF8.items():
+    for seq, name in list(INVALID_LINE_SEPARATOR_UTF8.items()):
       if next_line_contents.find(seq) != -1:
         self._problems.OtherProblem(
           "Line contains %s" % name,

--- a/transitfeed/util.py
+++ b/transitfeed/util.py
@@ -21,7 +21,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import input
 from builtins import next
-from builtins import str
+from future.utils import text_type as str
 from past.builtins import basestring
 from builtins import object
 from past.utils import old_div

--- a/transitfeed/version.py
+++ b/transitfeed/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.2.16'
+__version__ = '1.3.0'

--- a/unusual_trip_filter.py
+++ b/unusual_trip_filter.py
@@ -21,7 +21,10 @@ Filters out trips which are not on the defualt routes and
 For usage information run unusual_trip_filter.py --help
 """
 from __future__ import print_function
+from __future__ import division
 
+from builtins import object
+from past.utils import old_div
 __author__ = 'Jiri Semecky <jiri.semecky@gmail.com>'
 
 import codecs
@@ -61,8 +64,8 @@ class UnusualTripFilter(object):
       return
     self.info('Filtering infrequent trips for route %s.' % route.route_id)
     trip_count = len(route.trips)
-    for pattern_id, pattern in route.GetPatternIdTripDict().items():
-      ratio = float(1.0 * len(pattern) / trip_count)
+    for pattern_id, pattern in list(route.GetPatternIdTripDict().items()):
+      ratio = float(old_div(1.0 * len(pattern), trip_count))
       if not self._force:
         if (ratio < self._threshold):
           self.info("\t%d trips on route %s with headsign '%s' recognized "
@@ -92,7 +95,7 @@ class UnusualTripFilter(object):
   def filter(self, dataset):
     """Mark unusual trips for all the routes in the dataset."""
     self.info('Going to filter infrequent routes in the dataset')
-    for route in dataset.routes.values():
+    for route in list(dataset.routes.values()):
       self.filter_line(route)
 
   def info(self, text):

--- a/upgrade_translations.py
+++ b/upgrade_translations.py
@@ -68,6 +68,7 @@ Translations in GTFS-Translations format.
 
 from __future__ import print_function
 
+from builtins import object
 import csv
 import os
 import os.path
@@ -235,7 +236,7 @@ class OldTranslations(object):
           headsign-1,en,To Palace
         """
         n_occurences_of_original = {}
-        for trans_id, translations in self.translations_map.items():
+        for trans_id, translations in list(self.translations_map.items()):
             try:
                 original_name = translations[self.feed_language]
             except KeyError:
@@ -248,7 +249,7 @@ class OldTranslations(object):
 
         self.context_dependent_names = set(
             name
-            for name, occur in n_occurences_of_original.items()
+            for name, occur in list(n_occurences_of_original.items())
             if occur > 1)
         print('Total context-dependent translations: %d' %
               len(self.context_dependent_names))
@@ -347,7 +348,7 @@ class TableTranslator(object):
         translations_map = self.old_translations.translations_map
         context_dependent_names = self.old_translations.context_dependent_names
         out_row = row
-        for field_name, field_value in row.items():
+        for field_name, field_value in list(row.items()):
             if not is_translatable_field(field_name):
                 continue
             field_translations = translations_map.get(field_value)
@@ -361,7 +362,7 @@ class TableTranslator(object):
                 value_in_feed_lang in context_dependent_names)
             record_id = self.record_id_helper.get_record_id(row)
             record_sub_id = self.record_id_helper.get_record_sub_id(row)
-            for language, translation in field_translations.items():
+            for language, translation in list(field_translations.items()):
                 if language == feed_language:
                     continue
                 if use_record_id:
@@ -382,7 +383,7 @@ class TableTranslator(object):
 
     def write_for_field_values(self):
         for ((field_name, language, field_value),
-             translation) in self.translations_for_values.items():
+             translation) in list(self.translations_for_values.items()):
             self._write_translation_row({
                 'table_name': self.table_name,
                 'field_name': field_name,

--- a/visualize_pathways.py
+++ b/visualize_pathways.py
@@ -40,6 +40,8 @@ Usage:
 
 from __future__ import print_function
 
+from builtins import str
+from builtins import object
 from enum import Enum
 import argparse
 import csv
@@ -171,14 +173,14 @@ class GtfsReader(object):
 
     @property
     def locations(self):
-        return self._locations_map.values()
+        return list(self._locations_map.values())
 
     def get_pathway(self, stop_id):
         return self._pathways_map[stop_id]
 
     @property
     def pathways(self):
-        return self._pathways_map.values()
+        return list(self._pathways_map.values())
 
     def _read_locations(self):
         self._locations_map = self._read_table('stops', GtfsLocation)
@@ -210,7 +212,7 @@ def escape_graphviz_id(gtfs_id):
 
 
 def truncate_string(s, max_length=20):
-    s = unicode(s, 'utf-8', errors='ignore')
+    s = str(s, 'utf-8', errors='ignore')
     if max_length > 0 and len(s) > max_length:
         s = u'%s..%s' % (s[:max_length - 4], s[-2:])
     return s.encode('utf-8')
@@ -243,7 +245,7 @@ class GraphViz(object):
 
     def __str__(self):
         result = 'digraph D {\n  node [ %s ]\n' % Attributes(style='filled')
-        for cluster in self.clusters.values():
+        for cluster in list(self.clusters.values()):
             result += '\n  %s\n' % cluster.indent(1)
         for node in self.nodes:
             result += '  %s\n' % node
@@ -292,7 +294,7 @@ class GraphCluster(object):
                 style='filled',
                 color=self.color,
                 label=self.label))
-        for cluster in self.clusters.values():
+        for cluster in list(self.clusters.values()):
             result += '\n%s  %s\n' % (indent_str, cluster.indent(level + 1))
         for node in self.nodes:
             result += '\n%s  %s\n' % (indent_str, node)


### PR DESCRIPTION
This adapts the transitfeed project to run in both Python 2 and 3. The steps taken:

- ran `futurize` command on the codebase
- updated version
- updated README to explain our reason for forking
- changed a couple of imports to fix errors we encountered whilst running in a Python 2 environment