### PR TITLE
Fix import error during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ for help on creating Windows executables.
 from distutils.core import setup
 import glob
 import os.path
-from transitfeed import __version__ as VERSION
+from transitfeed.version import __version__ as VERSION
 
 try:
   import py2exe


### PR DESCRIPTION
The installation of this fork fails due to an attempt to use the `future` package in the `setup.py` script before it has been installed. The fix is to import the package version into the setup script in a more specific way, to avoid importing unneeded modules during installation.